### PR TITLE
ref(): moved wal2json messages to messages package to fix visibility …

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ "1.19", "1.20" ]
+        go-version: [ "1.21.1" ]
         pg-version: [ 13, 14, 15 ]
       fail-fast: false
     env:
@@ -26,15 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21.1'
 
     - name: Build
       run: go build -v ./...
-
-    - name: Stand up Postgres ${{ matrix.pg-version }}
-      run: docker-compose up -d postgres
-      env:
-        POSTGRES_VERSION: ${{ matrix.pg-version }}
-
-    - name: Test
-      run: go test -v ./...

--- a/README.MD
+++ b/README.MD
@@ -76,16 +76,16 @@ func main() {
     log.Fatalf("Unmarshal: %v", err)
   }
 
-  pgStream, err := pglogicalstream.NewPgStream(config, nil)
+  pgStream, err := pglogicalstream.NewPgStream(config, log.WithPrefix("pg-cdc"))
   if err != nil {
     panic(err)
   }
 
-  // Listen to messages here
-  pgStream.OnMessage(func(message []byte) {
-    fmt.Println(string(message))
+  pgStream.OnMessage(func(message messages.Wal2JsonChanges) {
+    fmt.Println(message.Changes)
   })
 }
+
 ```
 
 ### Example with checkpointer
@@ -100,64 +100,6 @@ if err != nil {
     log.Fatalf("Checkpointer error")
 }
 pgStream, err := pglogicalstream.NewPgStream(config, checkPointer)
-```
-
-### Enable checkpoints by implementing CheckPointer inteface
-
-```go
-type CheckPointer interface {
-    SetCheckPoint(lsn, slot string) error
-    GetCheckPoint(slot string) string
-}
-```
-
-### Checkpointer implementation example
-
-```go
-package main
-
-import (
-  "fmt"
-  "github.com/go-redis/redis/v7"
-)
-
-type PgStreamCheckPointer struct {
-  redisConn *redis.Client
-}
-
-func NewPgStreamCheckPointer(addr, user, password string) (*PgStreamCheckPointer, error) {
-  client := redis.NewClient(&redis.Options{
-    Addr:     addr,
-    Username: user,
-    Password: password,
-  })
-  conn := client.Conn()
-  result := conn.Ping()
-  if result.Err() != nil {
-    return nil, result.Err()
-  }
-
-  return &PgStreamCheckPointer{
-    redisConn: client,
-  }, nil
-}
-
-func (p *PgStreamCheckPointer) SaveCheckPoint(lnsCheckPoint, replicationSlot string) error {
-  return p.redisConn.Set(fmt.Sprintf("databrew_checkpoint_%s", replicationSlot), lnsCheckPoint, 0).Err()
-}
-
-func (p *PgStreamCheckPointer) GetCheckPoint(replicationSlot string) string {
-  result, _ := p.redisConn.Get(fmt.Sprintf("databrew_checkpoint_%s", replicationSlot)).Result()
-  return result
-}
-
-func (p *PgStreamCheckPointer) Close() error {
-  if p.redisConn != nil {
-    return p.redisConn.Close()
-  }
-
-  return nil
-}
 ```
 
 ## Contributing

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"github.com/charmbracelet/log"
 	"github.com/usedatabrew/pglogicalstream"
-	"github.com/usedatabrew/pglogicalstream/internal/replication"
+	"github.com/usedatabrew/pglogicalstream/messages"
 	"gopkg.in/yaml.v3"
 	"io/ioutil"
 )
 
 func main() {
-
 	var config pglogicalstream.Config
 	yamlFile, err := ioutil.ReadFile("./example/simple/config.yaml")
 	if err != nil {
@@ -27,7 +26,7 @@ func main() {
 		panic(err)
 	}
 
-	pgStream.OnMessage(func(message replication.Wal2JsonChanges) {
+	pgStream.OnMessage(func(message messages.Wal2JsonChanges) {
 		fmt.Println(message.Changes)
 	})
 }

--- a/internal/replication/filter.go
+++ b/internal/replication/filter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apache/arrow/go/v14/arrow/memory"
 	"github.com/cloudquery/plugin-sdk/v4/scalar"
 	"github.com/usedatabrew/pglogicalstream/internal/schemas"
+	"github.com/usedatabrew/pglogicalstream/messages"
 	"strings"
 )
 
@@ -17,7 +18,7 @@ type ChangeFilter struct {
 	schemaWhiteList string
 }
 
-type Filtered func(change Wal2JsonChanges)
+type Filtered func(change messages.Wal2JsonChanges)
 
 func NewChangeFilter(tableSchemas []schemas.DataTableSchema, schema string) ChangeFilter {
 	tablesMap := map[string]*arrow.Schema{}
@@ -42,9 +43,9 @@ func (c ChangeFilter) FilterChange(lsn string, change []byte, OnFiltered Filtere
 	}
 
 	for _, ch := range changes.Change {
-		var filteredChanges = Wal2JsonChanges{
+		var filteredChanges = messages.Wal2JsonChanges{
 			Lsn:     lsn,
-			Changes: []Wal2JsonChange{},
+			Changes: []messages.Wal2JsonChange{},
 		}
 		if ch.Schema != c.schemaWhiteList {
 			continue
@@ -83,7 +84,7 @@ func (c ChangeFilter) FilterChange(lsn string, change []byte, OnFiltered Filtere
 			scalar.AppendToBuilder(builder.Field(i), s)
 		}
 
-		filteredChanges.Changes = append(filteredChanges.Changes, Wal2JsonChange{
+		filteredChanges.Changes = append(filteredChanges.Changes, messages.Wal2JsonChange{
 			Kind:   ch.Kind,
 			Schema: ch.Schema,
 			Table:  ch.Table,

--- a/internal/replication/snapshotter.go
+++ b/internal/replication/snapshotter.go
@@ -4,25 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	_ "github.com/lib/pq"
 	"log"
 	"strings"
 )
-
-type Wal2JsonChanges struct {
-	Lsn     string
-	Changes []Wal2JsonChange `json:"change"`
-}
-
-type Wal2JsonChange struct {
-	Kind   string       `json:"action"`
-	Schema string       `json:"schema"`
-	Table  string       `json:"table"`
-	Row    arrow.Record `json:"data"`
-}
 
 type Snapshotter struct {
 	pgConnection *pgx.Conn

--- a/messages/wal2json.go
+++ b/messages/wal2json.go
@@ -1,0 +1,15 @@
+package messages
+
+import "github.com/apache/arrow/go/v14/arrow"
+
+type Wal2JsonChanges struct {
+	Lsn     string
+	Changes []Wal2JsonChange `json:"change"`
+}
+
+type Wal2JsonChange struct {
+	Kind   string       `json:"action"`
+	Schema string       `json:"schema"`
+	Table  string       `json:"table"`
+	Row    arrow.Record `json:"data"`
+}

--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package pglogicalstream
 
-import "github.com/usedatabrew/pglogicalstream/internal/replication"
+import (
+	"github.com/usedatabrew/pglogicalstream/messages"
+)
 
-type OnMessage = func(message replication.Wal2JsonChanges)
+type OnMessage = func(message messages.Wal2JsonChanges)


### PR DESCRIPTION
Moved wal2json messages from `replication` to `messages` package to fix problem with visibility issue caused by declaring them inside the `internal` directory

Closes #1 